### PR TITLE
Update footer copyright year to 2024

### DIFF
--- a/app/views/index.ejs
+++ b/app/views/index.ejs
@@ -95,7 +95,7 @@
         </section>
     </main>
     <footer>
-        <p>&copy; 2023 Podcast App</p>
+        <p>&copy; 2024 Podcast App</p>
     </footer>
 </body>
 </html>


### PR DESCRIPTION
This pull request includes a small change to the `app/views/index.ejs` file. The change updates the copyright year from 2023 to 2024 in the footer section.